### PR TITLE
Decouple Python updates from documentation versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ to the separate `:local` images.
 
 ## Development
 
-Native development requires JDK 25 and Python 3.13.14. Running `./gradlew run` starts
-only the Kotlin service, so the Python adapter must already be listening on port 8081
-or `BACKEND_URL` must point to another instance.
+Native development requires JDK 25 and the Python version pinned in
+[`.python-version`](.python-version). Running `./gradlew run` starts only the Kotlin
+service, so the Python adapter must already be listening on port 8081 or
+`BACKEND_URL` must point to another instance.
 
 Setup, test, SBOM and dependency-update commands are in
 [Development](docs/development.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - JDK 25;
-- Python 3.13.14, matching [`.python-version`](../.python-version);
+- Python matching [`.python-version`](../.python-version);
 - Docker with the Compose plugin for container tests and the simplest full-stack
   setup.
 
@@ -205,5 +205,5 @@ security alerts, is eligible for squash automerge only after required CI is gree
 the branch is current. Renovate itself performs merges during the first three days of
 each month; native platform automerge stays disabled so it cannot bypass that window.
 
-When Renovate changes a direct Python input, regenerate and commit the corresponding
-lockfile rather than accepting an incomplete direct-file-only update.
+Python dependency inputs are tested directly; this repository does not maintain a
+generated Python lockfile.

--- a/scripts/validate-docs.py
+++ b/scripts/validate-docs.py
@@ -17,7 +17,6 @@ DOCS_DIRECTORY = ROOT / "docs"
 OPENAPI = ROOT / "src/main/resources/openapi/stock-analyst-v1.json"
 COMPOSE = ROOT / "docker-compose.yml"
 BUILD_GRADLE = ROOT / "build.gradle.kts"
-PYTHON_VERSION = ROOT / ".python-version"
 CI_WORKFLOW = ROOT / ".github/workflows/ci-build.yml"
 BACKEND_PROVIDER_MODULE = (
     ROOT / "src/main/kotlin/net/bobinski/stockanalyst/BackendProviderModule.kt"
@@ -284,14 +283,7 @@ def validate_configuration_docs(errors: list[str]) -> int:
             + backend_default_match.group(1)
         )
 
-    python_version = PYTHON_VERSION.read_text(encoding="utf-8").strip()
     development = (DOCS_DIRECTORY / "development.md").read_text(encoding="utf-8")
-    if python_version not in development:
-        errors.append(
-            "development guide does not mention the version from .python-version: "
-            + python_version
-        )
-
     build_gradle = BUILD_GRADLE.read_text(encoding="utf-8")
     toolchain_match = re.search(r"jvmToolchain\((\d+)\)", build_gradle)
     if toolchain_match is None:


### PR DESCRIPTION
## Summary\n- point documentation at .python-version instead of duplicating its exact value\n- remove the exact-version documentation gate\n- correct stale lockfile guidance\n\n## Validation\n- Python syntax compilation\n- documentation validator